### PR TITLE
Test files

### DIFF
--- a/twitter/test_earthquake.py
+++ b/twitter/test_earthquake.py
@@ -1,0 +1,92 @@
+import math
+import pytest
+import pandas as pd
+import numpy as np
+
+import new_kandilli_scrape as em 
+
+
+@pytest.fixture
+def quake_sample():
+    return {
+        'date': '2025.08.03',
+        'time': '13:41:58',
+        'latitude': '36.2197',
+        'longitude': '36.2042',
+        'depth_km': '10.0',
+        'ML': '5.0',
+        'Mw': '5.2'
+    }
+
+
+@pytest.fixture
+def fake_cities(monkeypatch):
+    # Simple cities dataframe
+    data = pd.DataFrame({
+        "name": ["Ankara", "Istanbul"],
+        "latitude": [39.9334, 41.0082],
+        "longitude": [32.8597, 28.9784],
+        "feature_code": ["PPLC", "PPLA"],
+        "country_code": ["TR", "TR"],
+    })
+    em.cities_data = data
+    coords_rad = np.radians(data[["latitude", "longitude"]].values)
+    em.ball_tree = em.BallTree(coords_rad, metric="haversine")
+    return data
+
+def test_get_last_earthquake_date(monkeypatch):
+    class FakeTable:
+        def get_item(self, Key):
+            return {"Item": {"value": "2025.08.03"}}
+
+    dt = em._get_last_earthquake_date(FakeTable())
+    assert dt.year == 2025
+    assert dt.month == 8
+    assert dt.day == 3
+
+
+def test_distance_to_nearest_settlement(fake_cities):
+    dist, name = em._distance_to_nearest_settlement(39.9, 32.8)  # somewhere in Ankara
+    assert name in ["Ankara", "Istanbul"]
+    assert dist >= 0.0
+
+
+def test_beta_and_a7(monkeypatch):
+    # Mock boto3 S3 Object
+    class FakeBody:
+        def read(self):
+            return b'{"c1":5,"a5":1.0,"a6":0.5,"a7":2.0}'
+
+    class FakeObject:
+        def get(self):
+            return {"Body": FakeBody()}
+
+    class FakeBoto3:
+        def Object(self, bucket, key):
+            return FakeObject()
+
+    monkeypatch.setattr(em, "boto3", type("Boto3", (), {"resource": lambda *args, **kwargs: FakeBoto3()})())
+
+    beta, a7 = em._beta_and_a7(6.0)
+    assert isinstance(beta, float)
+    assert isinstance(a7, float)
+    assert math.isclose(a7, 2.0)
+
+
+def test_determine_Svalue_and_ttl(fake_cities, monkeypatch, quake_sample):
+    # Mock _beta_and_a7 and _is_offshore
+    monkeypatch.setattr(em, "_beta_and_a7", lambda M: (1.1, 2.0))
+    monkeypatch.setattr(em, "_is_offshore", lambda lat, lon: False)
+
+    S, ttl = em._determine_earthquake_Svalue_and_ttl(quake_sample)
+    assert S > 0
+    assert ttl > 0
+
+
+def test_calculate_danger_radius(monkeypatch, quake_sample):
+    monkeypatch.setattr(em, "_beta_and_a7", lambda M: (1.1, 2.0))
+    monkeypatch.setattr(em, "_is_offshore", lambda lat, lon: False)
+
+    radius = em.calculate_earthquake_danger_radius(quake_sample)
+    assert isinstance(radius, float)
+    assert radius >= 0

--- a/twitter/test_tweet.py
+++ b/twitter/test_tweet.py
@@ -1,0 +1,161 @@
+import pytest
+import re
+from unittest.mock import Mock, MagicMock
+import tweet_preprocessing2 as tp
+
+
+class TestTextCleaningFunctions:
+
+    def test_remove_hashtags(self):
+        text = "bu bir #deneme #testtir ve önemli."
+        expected = "bu bir   ve önemli."
+        assert tp.remove_hashtags(text) == expected
+
+    def test_remove_links(self):
+        # Remove link
+        text = "Bilgi: https://example.com/page?id=1 ve www.google.net/ara"
+        expected = "Bilgi:  ve "
+        assert tp.remove_links(text) == expected
+
+    def test_remove_non_unicode(self):
+        # Keep only Turkish alphabet letters, numbers, and spaces
+        text = "Hey! Bu bir test: 123. Dolar ($) ne oldu?"
+        expected = "Hey Bu bir test 123 Dolar  ne oldu"
+        assert tp.remove_non_unicode(text) == expected
+
+    def test_word_count_filter_pass(self):
+        # Keep if more than 3 words
+        text = "bu metin uzun yeterli"
+        assert tp.word_count_filter(text, min_words=3) is True
+
+    def test_word_count_filter_fail(self):
+        # Exactly 3 words, should fail 
+        text = "bu kısa metin"
+        assert tp.word_count_filter(text, min_words=3) is False
+        assert tp.word_count_filter("", min_words=3) is False
+
+    def test_remove_keywords_drop(self):
+        # Drops tweet when keyword found
+        text = "acil maddi destek lazım buraya"
+        assert tp.remove_keywords(text) == ""
+
+    def test_remove_keywords_keep(self):
+        # Keep tweet if no keyword found
+        text = "acil yardım ve işbirliği gerekli"
+        assert tp.remove_keywords(text) == text
+
+
+class TestNLPFunctions:
+
+    def test_normalize_text_no_normalizer(self, monkeypatch):
+        # Test case where z_normalizer is not installed
+        monkeypatch.setattr(tp, 'z_normalizer', None)
+        text = "bu bir deneme metnidir"
+        assert tp.normalize_text(text) == text
+
+    def test_normalize_text_with_mock_normalizer(self, monkeypatch):
+        # Test case where z_normalizer is mocked
+        mock_normalizer = Mock()
+        mock_normalizer.normalize.return_value = "normalized text"
+        monkeypatch.setattr(tp, 'z_normalizer', mock_normalizer)
+        
+        text = "bu bır dnm mtnıdır"
+        result = tp.normalize_text(text)
+        
+        mock_normalizer.normalize.assert_called_once_with(text)
+        assert result == "normalized text"
+
+    def test_lemmatize_text_no_tools(self, monkeypatch):
+        # fallback test
+        monkeypatch.setattr(tp, 'z_morph', None)
+        monkeypatch.setattr(tp, 'z_zeyrek', None)
+        text = "gelişmeleri takip etmekteyiz"
+  
+        assert tp.lemmatize_text(text) == text
+
+    def test_lemmatize_text_with_mock_morphology(self, monkeypatch):
+        # Test Zemberek Morphology
+        mock_morph = MagicMock()
+        
+        # Mocking the analysis result 1
+        mock_analysis1 = Mock()
+        mock_analysis1.lemma = "gelişme"
+        
+        # Mocking the analysis result 2
+        mock_analysis2 = Mock()
+        mock_analysis2.lemma = "takip"
+        
+        # Mock the analyze method to return the specific mock results
+        mock_morph.analyze.side_effect = [[mock_analysis1], [mock_analysis2]]
+        
+        monkeypatch.setattr(tp, 'z_morph', mock_morph)
+        monkeypatch.setattr(tp, 'z_zeyrek', None) # Ensure z_zeyrek is not used
+        
+        text = "gelişmeleri takip"
+        expected = "gelişme takip"
+        
+        result = tp.lemmatize_text(text)
+        
+        assert result == expected
+        mock_morph.analyze.call_count == 2
+        
+    def test_lemmatize_text_with_mock_zeyrek(self, monkeypatch):
+        # fallback morphology
+        mock_zeyrek = Mock()
+        # Mocking the lemmatized result
+        mock_zeyrek.lemmatize.return_value = [("gelen", ["gel"]), ("bilgiye", ["bilgi"])]
+        
+        monkeypatch.setattr(tp, 'z_morph', None) # Ensure z_morph is not used
+        monkeypatch.setattr(tp, 'z_zeyrek', mock_zeyrek)
+        
+        text = "gelen bilgiye"
+        expected = "gel bilgi"
+        
+        result = tp.lemmatize_text(text)
+        
+        mock_zeyrek.lemmatize.assert_called_once_with(text)
+        assert result == expected
+
+
+
+class TestPipeline:
+
+    def test_clean_tweet_full_pipeline(self, monkeypatch):
+        # Setup mocks for the NLP parts 
+        mock_normalizer = Mock()
+        mock_normalizer.normalize.return_value = "normalized text"
+        mock_morph = MagicMock()
+        mock_morph.analyze.side_effect = lambda x: [Mock(lemma=x + "_lemma")]
+        
+        monkeypatch.setattr(tp, 'z_normalizer', mock_normalizer)
+        monkeypatch.setattr(tp, 'z_morph', mock_morph)
+        monkeypatch.setattr(tp, 'z_zeyrek', None) # Disable zeyrek
+        
+        # Test input
+        raw_text = "Acil YARDIMM!!! Lütfeeeen geliiin, bakın: https://t.co/url #deprem"
+        
+        result = tp.clean_tweet(raw_text)
+        
+        mock_normalizer.normalize.assert_called_once() 
+        
+        assert result == "normalized_lemma text_lemma"
+
+
+    def test_clean_tweet_fail_word_count(self, monkeypatch):
+        # Ensure it returns an empty string if word count is too low
+        raw_text = "#help acil" 
+        monkeypatch.setattr(tp, 'z_normalizer', None)
+        monkeypatch.setattr(tp, 'z_morph', None)
+
+        result = tp.clean_tweet(raw_text, min_words=2) # 2 words > 2 is False
+        assert result == ""
+        
+    def test_clean_tweet_fail_banned_keyword(self, monkeypatch):
+        # Ensure it returns an empty string if a banned keyword is found
+        raw_text = "lütfen allahım yardım etsin"
+        monkeypatch.setattr(tp, 'z_normalizer', None)
+        monkeypatch.setattr(tp, 'z_morph', None)
+        
+        # For example the key word "allahım" is banned
+        result = tp.clean_tweet(raw_text)
+        assert result == ""


### PR DESCRIPTION
To test the Kandilli scrape part, changes to the Kandilli scrape code must be made to create mock DynamoDB tables. Using the Kandilli scrape code available on GitHub will not work for testing. There are no major issues in the text preprocessing code, all tests pass. However, the to_lower function has trouble converting "I" to "ı" in Turkish; instead, it converts it to "i". Converts "İ" to "i" correctly